### PR TITLE
site_settingsのMigration、Model等をSiteManagerに移動する

### DIFF
--- a/Test/Case/Model/Holiday/ExtractHolidayTest.php
+++ b/Test/Case/Model/Holiday/ExtractHolidayTest.php
@@ -34,7 +34,7 @@ class HolidayExtractHolidayTest extends NetCommonsGetTest {
  * @var array
  */
 	public $fixtures = array(
-		'plugin.net_commons.site_setting',
+		'plugin.site_manager.site_setting',
 		'plugin.holidays.holiday',
 	);
 

--- a/Test/Case/Model/Holiday/GetHolidayInYearTest.php
+++ b/Test/Case/Model/Holiday/GetHolidayInYearTest.php
@@ -34,7 +34,7 @@ class HolidayGetHolidayInYearTest extends NetCommonsGetTest {
  * @var array
  */
 	public $fixtures = array(
-		'plugin.net_commons.site_setting',
+		'plugin.site_manager.site_setting',
 		'plugin.holidays.holiday',
 	);
 


### PR DESCRIPTION
サイト管理が出来上がったことで、site_settingsのMigration、Model等をNetCommonsプラグインからSiteManagerに移動しました。

https://github.com/NetCommons3/NetCommons3/issues/104

@RikaFujiwara 
