### PR TITLE
fix: getHolidayで取得するカラム数を減らして、getHolidayInYearでキャッシュを作らないように修正。

### DIFF
--- a/Model/Holiday.php
+++ b/Model/Holiday.php
@@ -93,12 +93,17 @@ class Holiday extends HolidaysAppModel {
  */
 	public function getHoliday($from, $to) {
 		$holidays = $this->cacheFindQuery('all', array(
+			'fields' => array(
+				'Holiday.id',
+				'Holiday.holiday',
+				'Holiday.title'
+			),
 			'conditions' => array(
 				'language_id' => Current::read('Language.id'),
 				'holiday >=' => $from,
 				'holiday <=' => $to
 			),
-			'recursive' => 0,
+			'recursive' => -1,
 			'order' => array('holiday')
 		));
 		return $holidays;
@@ -120,7 +125,15 @@ class Holiday extends HolidaysAppModel {
 		}
 		$from = $year . '-01-01';
 		$to = $year . '-12-31';
-		$holidays = $this->getHoliday($from, $to);
+		$holidays = $this->Find('all', array(
+			'conditions' => array(
+				'language_id' => Current::read('Language.id'),
+				'holiday >=' => $from,
+				'holiday <=' => $to
+			),
+			'recursive' => 0,
+			'order' => array('holiday')
+		));
 		return $holidays;
 	}
 


### PR DESCRIPTION
カレンダーや施設予約で使用するキャッシュが大きくなりやすいため、
カレンダーや施設予約で祝日設定を取得するときに使用するgetHolidayの取得カラムをidとholidayとtitleだけに修正しました。
また、管理画面の祝日設定で使用するgetHolidayInYearではキャッシュは使用せずに、
以前までと同じカラムを取得できるように修正しました。
よろしければマージしてください。